### PR TITLE
Icons, 2902d, and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,23 @@ Configuration is done via a TOML file. Here's a simple example configuration:
     client_id = "ambient2mqtt"
     topic_prefix = "weather"
     topic = "ws-2902"
+
 [hass]
     discovery = true
     discovery_prefix = "homeassistant"
     object_id = "ws-2902a"
+    object_id = "ws-2902d"
+    device_model = "ws-2902d"
+    device_name = "ws-2902d"
+
+[influx]
+    Hostname = "localhost"
+    Port = 8086
+    Database = "ambientweather"
 
 ```
+
+Influx requests are 1.x.
 
 License
 -------

--- a/ambient2mqtt.go
+++ b/ambient2mqtt.go
@@ -228,6 +228,9 @@ func getHassMQTTConfig(key string, unique_id string) hassMqttConfig {
 		device_config.Device = device
 		device_config.Qos = 1
 		device_config.UniqueId = getHassMQTTUniqueId(key, unique_id)
+		if value.Icon != nil {
+			device_config.Icon = *value.Icon
+		}
 	}
 
 	return device_config

--- a/components.toml
+++ b/components.toml
@@ -51,12 +51,14 @@ name="barometer_absolute"
 platform="sensor"
 device_class="pressure"
 unit="inHg"
+icon="mdi:gauge"
 
 [sensors.baromrelin]
 name="barometer_relative"
 platform="sensor"
 device_class="pressure"
 unit="inHg"
+icon="mdi:gauge"
 
 [sensors.winddir]
 name="wind_direction"
@@ -81,6 +83,12 @@ name="wind_speed"
 platform="sensor"
 icon="mdi:weather-windy"
 unit="mph"
+
+[sensors.yearlyrainin]
+name="yearly_rain"
+platform="sensor"
+icon="mdi:water"
+unit="in"
 
 [sensors.monthlyrainin]
 name="monthly_rain"
@@ -123,6 +131,7 @@ name="solar_radiation"
 platform="sensor"
 device_class="illuminance"
 unit="W/m^2"
+icon="mdi:sun-wireless"
 
 [sensors.uv]
 name="uv_index"


### PR DESCRIPTION
* fixed icon not being sent to hass
* added missing icons for some sensors
* added a 2902d-specific sensor to components
* added readme block for influx

Forked it for my own use last night, works great with a 2902-d. I prefer this over [ambientweather2mqtt](https://github.com/neilenns/ambientweather2mqtt) because this tee's to influx 1.x automatically, and it's not a typescript hell. 

Just had a couple tweaks, thought I'd feed them back.